### PR TITLE
Add a trap which removes the lockfile on exit

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -17,6 +17,8 @@ LOG="/var/log/cron.log"
 echo "access_key=$ACCESS_KEY" >> /root/.s3cfg
 echo "secret_key=$SECRET_KEY" >> /root/.s3cfg
 
+trap "rm $LOCKFILE" EXIT
+
 if [ ! -e $LOG ]; then
   touch $LOG
 fi

--- a/run.sh
+++ b/run.sh
@@ -17,7 +17,7 @@ LOG="/var/log/cron.log"
 echo "access_key=$ACCESS_KEY" >> /root/.s3cfg
 echo "secret_key=$SECRET_KEY" >> /root/.s3cfg
 
-trap "rm $LOCKFILE" EXIT
+trap "rm -f $LOCKFILE" EXIT
 
 if [ ! -e $LOG ]; then
   touch $LOG


### PR DESCRIPTION
I had a few instances where the lock file would hang around after a failure, preventing any further scheduled runs.

Adding this simple trap has prevented that problem and has been in "production" for a while now with no issues.